### PR TITLE
Vertical zig-zag LED string support for Strip2D

### DIFF
--- a/lib/strip.py
+++ b/lib/strip.py
@@ -20,34 +20,39 @@ import sys
 import select
 import os
 
-# Signal handler to kill the application
-# Usage: signal.signal(signal.SIGINT, signal_handler)
 
 def signal_handler(_signal, _frame):
+  """
+  Signal handler to kill the application
+  Usage: signal.signal(signal.SIGINT, signal_handler)
+  """
   #print('Bye ...')
   strip.stop()
   os.kill(os.getpid(), signal.SIGKILL)
   sys.exit(0)
 
-# Convert string to array of tupples
-# Parameter s can be:
-#   abcdef
-#   'abcdef'
-#   "abcdef"
-#   ("abcdef", 123)
-#   [("abcdef", 123)]
-
-def toTuppleArray(s):
-  if ((s[0] == '"') or (s[0] == "'")):
-    s = "[(" + s + ")]"
-  elif not ((s[0] == '[') or (s[0] == '(')):
-    s = "[('" + s + "',)]"
-  elif s[0] == '(':
-    s = "[" + s + "]"
+def toTuppleArray(string):
+  """
+  Convert string to array of tupples
+  Parameter s can be:
+    abcdef
+    'abcdef'
+    "abcdef"
+    ("abcdef", 123)
+    [("abcdef", 123)]
+  """
+  if ((string[0] == '"') or (string[0] == "'")):
+    # String
+    string = "[(" + string + ")]"
+  elif not ((string[0] == '[') or (string[0] == '(')):
+    # not an Array or Tuple
+    string = "[('" + string + "',)]"
+  elif string[0] == '(':
+    # Tuple
+    string = "[" + string + "]"
   else:
     pass
-  #r = eval(s)
-  return eval(s) # pylint: disable=eval-used
+  return eval(string) # pylint: disable=eval-used
 
 
 def getAddr(addr = None):
@@ -72,12 +77,11 @@ def getAddr(addr = None):
   return addr
 
 
-#
-# The Artnet class provides operation for sending and receiving data
-# using the Artnet protocol.
-#
-
 class Artnet:
+  """
+  The Artnet class provides operation for sending and receiving data
+  using the Artnet protocol.
+  """
   localHost = "0.0.0.0"
   localPort = 6454
   sock = 0
@@ -123,21 +127,27 @@ class Artnet:
     self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     self.sock.bind((self.localHost, self.localPort))
 
-  # Shutdown the connection
   def close(self):
+    """
+    Shutdown the connection
+    """
     self.clear()
     self.sock.close()
 
-  # Clear the entire strip
   def clear(self):
+    """
+    Clear the entire strip
+    """
     data = self.dataHeader
     for _i in range(self.length):
       data += b"\x00\x00\x00"
     for _i, address in enumerate(self.addr):
       self.sock.sendto( data, address)
 
-  # Send the data of a strip
   def send(self, current_strip):
+    """
+    Send the data of a strip
+    """
     data = bytearray(3*current_strip.length)
     for i in reversed(range(current_strip.length)):
       c = current_strip.get(current_strip.length - i)
@@ -147,8 +157,10 @@ class Artnet:
     for _i, address in enumerate(self.addr):
       self.sock.sendto( self.dataHeader + data, address)
 
-  # Run poll for 5 seconds.
   def poll(self):
+    """
+    Run poll for 5 seconds.
+    """
     devices = []
     self.sock.setblocking(0)
     for _i, address in enumerate(self.addr):
@@ -168,17 +180,19 @@ class Artnet:
     self.sock.setblocking(1)
     return devices
 
-#
-# The Strip class defines operations for a 1-dimensional string of leds.
-#
 strip = None
 
 class Strip:
+  """
+  The Strip class defines operations for a 1-dimensional string of leds.
+  """
   length = 0
   rgb = []
 
-  # Constructor, creating a strip of length leds.
   def __init__(self, length, addr = None):
+    """
+    Constructor, creating a strip of length leds.
+    """
     self.length = length
     self.clear()
     self.artnet = Artnet(addr)
@@ -188,27 +202,35 @@ class Strip:
     global strip
     strip = self
 
-  # Stop this strip
   def stop(self):
+    """
+    Stop this strip
+    """
     if "globalStop" in dir(strip):
       self.globalStop(self) # pylint: disable=no-member
     self.artnet.close()
 
-  # Send the data of myself to the strip
   def send(self):
+    """
+    Send the data of myself to the strip
+    """
     self.artnet.send(self)
 
-  # Clear the entire strip with one color (default: black).
-  # Color is array: [r, g, b].
   def clear(self, color = None):
+    """
+    Clear the entire strip with one color (default: black).
+    Color is array: [r, g, b].
+    """
     if color and len(color):
       [r, g, b] = color
     else:
       [r, g, b] = [0, 0, 0]
     self.rgb = [[r, g, b] for x in range(self.length)]
 
-  # Set led at index to color.
   def set(self, index, color, alpha = -1):
+    """
+    Set led at index to color.
+    """
     if ((index >= 0) and (index < self.length)):
       [r, g, b] = color
       if alpha >= 0:
@@ -226,29 +248,37 @@ class Strip:
             b = 255
       self.rgb[self.length - 1 - index] = [r, g, b]
 
-  # Get color of led at index.
   def get(self, index):
+    """
+    Get color of led at index.
+    """
     if ((index >= 0) and (index < self.length)):
       [r, g, b] = self.rgb[self.length - 1 - index]
       return [r, g, b]
     else:
       return [0, 0, 0]
 
-  # Set a range of leds starting at index to the specified colors.
   def setm(self, index, colors):
+    """
+    Set a range of leds starting at index to the specified colors.
+    """
     length = len(colors)
     for i in range(length):
       self.set(index + i, colors[i])
 
-  # Get the colors of a range of leds starting at index up to given length.
   def getm(self, index, length):
+    """
+    Get the colors of a range of leds starting at index up to given length.
+    """
     a = []
     for i in range(length):
       a.append(self.get(index + i))
     return a
 
-  # Fade that strip by a factor a
   def fade(self, a):
+    """
+    Fade that strip by a factor a
+    """
     for i in range(self.length):
       [r, g, b] = self.rgb[i]
       r = int(float(r) * float(a))
@@ -256,25 +286,29 @@ class Strip:
       b = int(float(b) * float(a))
       self.rgb[i] = [r, g, b]
 
-  # Print strip contents to stdout.
   def print_(self):
+    """
+    Print strip contents to stdout.
+    """
     for i in range(self.length):
       print("strip ", i, self.rgb[i][0], self.rgb[i][1], self.rgb[i][2])
 
 
-#
-# The Strip2D class defines operations on a 2-dimensional led banner and
-# maps it to a Strip.
-#
 
 class Strip2D:
+  """
+  The Strip2D class defines operations on a 2-dimensional led banner and
+  maps it to a Strip.
+  """
   lenx = 0
   leny = 0
+  lengths = None
   fadeCount = 0
   strip = None
 
-  # Constructor, defining a led banner of width lenx and height leny.
-  def __init__(self, lenx, leny, addr = None):
+  def __init__(self, lenx, leny, *args, addr=None):
+    """Constructor, defining a led banner of width lenx and height leny."""
+
     self.lenx = lenx
     self.leny = leny
     #self.strip = Strip(lenx * leny, addr)
@@ -282,61 +316,74 @@ class Strip2D:
     #self.f = [.20 * math.sin(math.pi * i / 26) for i in range(1, 12)]
     self.f = [0.02, 0.03, 0.05, 0.09, 0.10, 0.11, 0.12, 0.13, 0.17, 0.19, 0.20]
 
-  # Send data to the strip
   def send(self):
-    for i in range(self.lenx * self.leny, self.strip.length):
-      self.strip.set(i, [0, 0, 0])
+    """Send data to the strip"""
+    if not self.lengths:
+      for i in range(self.lenx * self.leny, self.strip.length):
+        self.strip.set(i, [0, 0, 0])
     self.strip.send()
 
-  # Set the color of the led at (x, y).
   def set(self, x, y, color):
+    """Set the color of the led at (x, y)."""
     self.strip.set(x + y * self.lenx, color)
 
-  # Get the color of the led at (x, y).
   def get(self, x, y):
+    """Get the color of the led at (x, y)."""
     return self.strip.get(x + y * self.lenx)
 
-  # Rotate the banner contents 1 led to the right.
   def rotr(self):
+    """
+    Rotate the banner contents 1 led to the right.
+    """
     for y in range(self.leny):
       c = self.get(self.lenx - 1, y)
       for x in reversed(range(self.lenx - 1)):
         self.set(x + 1, y, self.get(x, y))
       self.set(0, y, c)
 
-  # Rotate the banner contents 1 led to the left.
   def rotl(self):
+    """
+    Rotate the banner contents 1 led to the left.
+    """
     for y in range(self.leny):
       c = self.get(0, y)
       for x in range(self.lenx - 1):
         self.set(x, y, self.get(x + 1, y))
       self.set(self.lenx - 1, y, c)
 
-  # Rotate the banner contents 1 led up.
   def rotu(self):
+    """
+    Rotate the banner contents 1 led up.
+    """
     c = self.strip.getm((self.leny - 1) * self.lenx, self.lenx)
     for y in reversed(range(self.leny - 1)):
       self.strip.setm((y + 1) * self.lenx, \
         self.strip.getm(y * self.lenx, self.lenx))
     self.strip.setm(0, c)
 
-  # Rotate the banner contents 1 led down.
   def rotd(self):
+    """
+    Rotate the banner contents 1 led down.
+    """
     c = self.strip.getm(0, self.lenx)
     for y in range(self.leny - 1):
       self.strip.setm(y * self.lenx, \
         self.strip.getm((y + 1) * self.lenx, self.lenx))
     self.strip.setm((self.leny - 1) * self.lenx, c)
 
-  # Set pattern for every y increment with step.
   def pattern(self, data, step):
+    """
+    Set pattern for every y increment with step.
+    """
     #length = len(data)
     for y in range(self.leny):
       for x in range(self.lenx):
         self.set(x, y, data[(x + y * step) % self.lenx])
 
-  # Fade that strip by a factor a
   def fade(self, a):
+    """
+    Fade that strip by a factor a
+    """
     for y in range(self.leny):
       for x in range(self.lenx):
         p = self.get(x, y)
@@ -346,25 +393,23 @@ class Strip2D:
         self.set(x, y, p)
 
   def coneFade(self, yy):
-    for y in range(self.leny):
-      if abs(y - yy) >= len(self.f):
+    for y_position in range(self.leny):
+      if abs(y_position - yy) >= len(self.f):
         f = self.f[len(self.f) - 1]
       else:
-        f = self.f[abs(y - yy)]
-      for x in range(self.lenx):
-        c = self.get(x, y)
+        f = self.f[abs(y_position - yy)]
+      for x_position in range(self.lenx):
+        c = self.get(x_position, y_position)
         c = [int(c[0] * f), int(c[1] * f), int(c[2] * f)]
 
-        self.set(x, y, c)
-        self.set(x, y, c)
+        self.set(x_position, y_position, c)
+        self.set(x_position, y_position, c)
 
-
-
-#
-# The Canvas class provides function for drawing on a Strip2D.
-#
 
 class Canvas:
+  """
+  The Canvas class provides function for drawing on a Strip2D.
+  """
   lenx = 0
   leny = 0
   strip2D = 0
@@ -374,12 +419,14 @@ class Canvas:
     self.leny = leny
     self.strip2D = Strip2D(lenx, leny)
 
-  # Draw a circle
   def circle(self, cx, cy, radius, color):
+    """
+    Draw a circle
+    """
     x = 0
     y = radius
     p = (5 - radius * 4) / 4
-    self.circlePoints(cx, cy, x, y, color)
+    self.circle_points(cx, cy, x, y, color)
     while x < y:
       x += 1
       if p < 0:
@@ -387,10 +434,12 @@ class Canvas:
       else:
         y -= 1
         p += 2 * (x - y) + 1
-      self.circlePoints(cx, cy, x, y, color)
+      self.circle_points(cx, cy, x, y, color)
 
-  # used by circle; do not use
-  def circlePoints(self, cx, cy, x, y, c):
+  def circle_points(self, cx, cy, x, y, c):
+    """
+    used by circle; do not use
+    """
     if x == 0:
       self.strip2D.set(cx, cy + y, c)
       self.strip2D.set(cx, cy - y, c)

--- a/singleSleeve/countdown.py
+++ b/singleSleeve/countdown.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import time
+
+import sys
+sys.path.append('../lib')
+from strip import Effect, Strip2D
+
+class Countdown(Effect):
+  endtime = None
+  direction = None
+
+  def __init__(self, strip2D, colors, epoch=None, direction="up"):
+    super(Countdown, self).__init__(strip2D)
+    self.strip2D.strip.clear()
+    self.colors = colors
+    self.endtime = epoch or (time.time() + 300)
+    self.direction = direction
+
+  def run(self, runtime = None):
+    if runtime is None:
+      if hasattr( sys, "maxint" ): # Python 2
+        runtime = sys.maxint
+      elif hasattr( sys, "maxsize" ): # Python 3
+        runtime = sys.maxsize
+
+    now = time.time()
+    leny = self.strip2D.leny
+
+    while (not self.quit) and ((time.time() - now) < runtime):
+      remainder = self.endtime - time.time()
+
+      if remainder <= 0:
+        # timeout
+        for y in range(leny):
+          v = self.direction == "down" and y or leny - y - 1
+          for x in range(self.strip2D.lenx):
+            self.strip2D.set( x, v, self.colors[5]) # timeout color
+      elif remainder <= 10:
+        # last 10 seconds
+        for y in range(leny):
+          v = self.direction == "down" and y or leny - y - 1
+          for x in range(self.strip2D.lenx):
+            # differentiate length over 10 sec
+            if y > remainder / 10 * leny:
+              self.strip2D.set( x, v, self.colors[4]) # 10 second color
+            else:
+              self.strip2D.set( x, v, self.colors[3]) # 1 minute color
+      elif remainder <= 60:
+        # last minute
+        for y in range(leny):
+          v = self.direction == "down" and y or leny - y - 1
+          for x in range(self.strip2D.lenx):
+            # differentiate length over 60-10 sec
+            if y > (remainder - 10) / 50 * leny:
+              self.strip2D.set( x, v, self.colors[3]) # 1 minute color
+            else:
+              self.strip2D.set( x, v, self.colors[2]) # 5 minute color
+      elif remainder <= 300:
+        # last 5 minutes
+        for y in range(leny):
+          v = self.direction == "down" and y or leny - y - 1
+          for x in range(self.strip2D.lenx):
+            # differentiate length over red/green 5-1 min
+            if y > (remainder - 60) / 240 * leny:
+              self.strip2D.set( x, v, self.colors[2]) # 5 minute color
+            else:
+              self.strip2D.set( x, v, self.colors[1]) # normal color
+      else:
+        # initial coloring (before 5 minute mark and timeout)
+        for y in range(leny):
+          for x in range(self.strip2D.lenx):
+            self.strip2D.set( x, y, self.colors[0]) # idle color
+
+      self.strip2D.send()
+      time.sleep(1.0)
+
+    self.quit = False
+
+
+
+"""
+./countdown.py addr=192.168.1.255
+./countdown.py [epoch] [up/down] 'addr=[("192.168.1.255", ), ("localhost", 7000)]'
+./countdown.py [epoch] [up/down] 'addr=[("192.168.1.255", 6454), ("localhost", 7000)]'
+"""
+if __name__ == "__main__":
+  colors = [
+    [0,0,0],    # idle (color before 5 minute mark)
+    [1,1,1],    # active (when the 5 minute progress starts)
+    [0,255,0],  # 5 minutes progress
+    [255,255,0],# 1 minute progress
+    [255,0,0],  # 10 seconds progress
+    [255,0,1],  # timeout (color after 0 second mark)
+  ]
+
+  direction = "up"
+  epoch = None
+
+  if len(sys.argv) > 2:
+    if sys.argv[1] == "down" or sys.argv[1] == "up":
+      direction = sys.argv[1]
+    else:
+      epoch = int( sys.argv[1] )
+  if len(sys.argv) > 3:
+    if sys.argv[2] == "down" or sys.argv[2] == "up":
+      direction = sys.argv[2]
+    else:
+      epoch = int( sys.argv[2] )
+
+  e = Countdown(Strip2D( 7, 21 ), colors, epoch, direction )
+
+  #e = Countdown(Strip2D( 21, 18, 15, 17, 15, 17 ), colors, 1640991600 ) # New year tz 1
+  e.run()

--- a/singleSleeve/eyes.py
+++ b/singleSleeve/eyes.py
@@ -188,7 +188,7 @@ class Eyes(Effect):
       for s in range( location, location + self.distance + 1 ):
         try:
           freespots.remove( s )
-        except ValueError():
+        except ValueError:
           pass
 
       eyes.append( Eye( self.strip2D, location, on, self.distance ) )

--- a/singleSleeve/life.py
+++ b/singleSleeve/life.py
@@ -12,13 +12,16 @@ from strip import Effect, Strip2D
 # Conrad's game of life
 
 class Life(Effect):
+  plane = None
 
   def __init__(self, strip2D):
     super(Life, self).__init__(strip2D)
     self.strip2D.strip.clear()
     self.strip2D.send()
     self.reset()
-    self.plane = None
+    y = self.strip2D.leny + 1
+    x = self.strip2D.lenx + 1
+    self.plane = [x[:] for x in [[0] * y] * x ]
 
   def step(self, count):
     self.strip2D.strip.clear([0, 0, 0])
@@ -26,7 +29,7 @@ class Life(Effect):
     #  self.reset()
     if (count % 20) == 0:
       for _i in range(int(20 / (math.log(self.getCount() + 1) + 1))):
-        self.plane[random.randint(0, 6)][random.randint(0, 20)] = 1
+        self.plane[random.randint(0, self.strip2D.lenx - 1)][random.randint(0, self.strip2D.leny - 1)] = 1
     else:
       self.updatePlane()
     self.draw(count)
@@ -36,7 +39,7 @@ class Life(Effect):
   def reset(self):
     self.plane = [[0 for y in range(21)] for x in range(7)]
     for _i in range(30):
-      self.plane[random.randint(0, 6)][random.randint(0, 20)] = 1
+      self.plane[random.randint(0, self.strip2D.lenx - 1)][random.randint(0, self.strip2D.leny - 1)] = 1
 
   def updatePlane(self):
     p = copy.deepcopy(self.plane)


### PR DESCRIPTION
This PR mainly is actually the essence of picking up this project again;

It adds support for using a LED string in up/down zig-zag direction (as compared to the existing spiral method) in the `Strip2D` class.
This allows one to decorate, for example a tree and still use this codebase.

An extra commit (c93ac39) was needed to mitigate problems working with arbitrary banner sizes.

I thoroughly tested it with the matrix.py code, but also with the newly created countdown script (47f2153) for new year's day; it functions very similar to the famous lightning talk progress bar; it activates on the 5-minute mark, draws a green progress bar, starts drawing a yellow progress bar in the last minute and a red one in the last 10 seconds.

Do note that all the `rot*` functions cannot work properly on the zig-zag mode since it has arbitrary heights, moving pixels in either direction causes either vertical synchronization problems or horizontal loss of pixels.