### PR TITLE
Added traffic light (multi threaded)

### DIFF
--- a/lib/strip.py
+++ b/lib/strip.py
@@ -197,7 +197,11 @@ class Strip:
     self.clear()
     self.artnet = Artnet(addr)
 
-    signal.signal(signal.SIGINT, signal_handler)
+    # ValueError: signal only works in main thread of the main interpreter
+    try:
+      signal.signal(signal.SIGINT, signal_handler)
+    except ValueError as _e:
+      pass
 
     global strip
     strip = self

--- a/resources/Trafficlight.svg
+++ b/resources/Trafficlight.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="43.965439mm"
+   height="103.23211mm"
+   viewBox="0 0 43.965439 103.23211"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(-80.212123,-40.500003)">
+    <path
+       id="rect4402"
+       style="opacity:1;stroke:#000000;stroke-width:20;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill"
+       d="M 90.212123,62.482719 H 114.17756 V 121.7494 H 90.212123 Z M 114.17756,121.7494 c 0,6.61787 -5.36485,11.98271 -11.98272,11.98271 -6.617869,0 -11.982713,-5.36484 -11.982717,-11.98271 -2e-6,-6.61787 5.364844,-11.98272 11.982717,-11.98272 6.61787,0 11.98272,5.36485 11.98272,11.98272 z m 0,-59.266681 c 0,6.617873 -5.36485,11.982719 -11.98272,11.982717 -6.617872,0 -11.982717,-5.364845 -11.982717,-11.982717 10e-7,-6.617871 5.364846,-11.982716 11.982717,-11.982716 6.61787,-2e-6 11.98272,5.364843 11.98272,11.982716 z" />
+    <circle
+       style="fill:#ff0000;fill-rule:evenodd;stroke-width:0.264583"
+       id="path1776"
+       cx="102.19484"
+       cy="62.482719"
+       r="11.982717" />
+    <circle
+       style="fill:#ffdb00;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="circle1893"
+       cx="102.19484"
+       cy="92.116081"
+       r="11.982717" />
+    <circle
+       style="fill:#4bff00;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="circle3697"
+       cx="102.19484"
+       cy="121.7494"
+       r="11.982717" />
+  </g>
+</svg>

--- a/singleSleeve/trafficlight.py
+++ b/singleSleeve/trafficlight.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+import time
+
+import sys
+import signal
+from threading import Semaphore, Thread, Event
+sys.path.append('../lib')
+from strip import Effect, Strip2D
+
+# Primary semaphore: first to get priority
+sema_prepare = Semaphore()
+# Actual green light semaphore
+sema_go = Semaphore()
+
+off = [ 0, 0, 0 ]
+red = [ 255, 0, 0 ]
+yellow = [ 255, 96, 0 ]
+green = [ 0, 255, 0 ]
+
+# Lights go from bottom to top
+none = [ off, off, off ]
+alllights = [ green, yellow, red ]
+
+traffic_stop = [ off, off, red ]
+traffic_prepare = [ off, off, red ] # choose between [ off, yellow, red ] or just [ off, off, red ]
+go = [ green, off, off ]
+traffic_caution = [off, yellow, off ]
+
+bridge_closed_indefinitely = [ red, off, red ]
+bridge_closed = [ off, off, red ]
+bridge_prepare = [ off, green, red ]
+bridge_go = [ off, green, off ]
+bridge_caution = [ off, off, red ]
+
+# TODO: automated (orange) with 2-way boats
+bridge = [
+            [ bridge_closed, 5, sema_go ] ,
+            [ bridge_prepare, 3.5, sema_prepare ],
+            [ bridge_go, 5, sema_go ],
+            [ bridge_caution, 3.5, sema_prepare ]
+          ]
+
+# Yellow light duration:
+# @80km/h → 5s
+# @70km/h → 4.5s
+# @50km/h → 3.5s
+# overlap stop time, stop+time, prepare+time, go+time, caution+time
+traffic = [
+            [ traffic_stop, 0, sema_go ],           # intersection release time (all red)
+            [ traffic_prepare, 1.5, sema_prepare ], # prepare time (see next NOTE)
+            [ go, 5, sema_go ],                     # green time
+            [ traffic_caution, 3.5, sema_prepare ]  # orange time
+          ]
+# NOTE: prepare time is calculated as a remainder of caution+stop time
+traffic[1][1] = max( traffic[0][1] + traffic[3][1] - traffic[1][1], 0 )
+
+# https://wetten.overheid.nl/BWBR0009151/2019-07-01 section 114
+# De frequentie van het knipperen bedraagt minimaal 40 en maximaal 60 onderbrekingen per minuut
+# met een licht-donkerverhouding van 1:1.
+disabled = [
+    [ traffic_caution, 1.1, None ],
+    [ none, 1.1, None ]
+  ]
+
+# Define the actual program here (traffic, disabled, bridge)
+program = traffic
+
+class Trafficlight(Effect):
+
+  sleepEvent = None
+  _quit = False
+
+  @property
+  def quit(self):
+    return self._quit
+
+  @quit.setter
+  def quit(self, value):
+    self._quit = value
+    # Kill the timer if we want to quit
+    if value:
+      print( "stopping timer" )
+      self.sleepEvent.set()
+
+  def __init__(self, strip2D):
+    super().__init__(strip2D)
+
+    self.strip2D.strip.globalStop = self.globalStop
+
+    addr = self.strip2D.strip.artnet.addr
+
+    self.extraLights = []
+    if len(addr) > 1:
+      for i in range(1, len(addr)):
+        stripCopy = Strip2D(7, 21)
+        stripCopy.strip.artnet.addr = [addr[i]]
+        self.extraLights.append( Trafficlight(stripCopy) )
+    self.strip2D.strip.artnet.addr = [addr[0]]
+
+  # Set the actual light
+  def setLight( self, lights ):
+    self.strip2D.strip.clear()
+
+    offset = -1
+    for y in range(self.strip2D.leny):
+      if y % 7 == 0:
+        offset += 1
+      for x in range(int(self.strip2D.lenx / 7 * 3)):
+        self.strip2D.set(x+0-offset, y, lights[offset])
+
+    self.strip2D.send()
+  def globalStop(self):
+    pass
+
+  def run(self, runtime = None):
+    self.sleepEvent = Event()
+
+    if runtime is None:
+      if hasattr( sys, "maxint" ): # Python 2
+        runtime = sys.maxint
+      elif hasattr( sys, "maxsize" ): # Python 3
+        runtime = sys.maxsize
+
+    # Don't use globalStop since apparently it is a child thread
+    # which has no control over the main thread.
+    try:
+      signal.signal(signal.SIGINT, self.signal_handler)
+    except ValueError as _e:
+      # Will catch the error if a thread tries to subscribe
+      pass
+
+    # Start with red
+    self.setLight( program[0][0] )
+
+    # Run the secondary lights
+    for light in self.extraLights:
+      thread = Thread(target = light.run, args = [])
+      thread.daemon = True
+      light.thread = thread
+      thread.start()
+
+    now = time.time()
+    while (not self.quit) and ((time.time() - now) < runtime):
+      if program[1][2] is not None:
+        program[1][2].acquire() # pylint: disable=consider-using-with
+      self.sleepEvent.wait( program[1][1] ) # prepare delay (warn+stop taken into account)
+      self.setLight( program[1][0] ) # prepare
+
+      if len( program ) > 2:
+        if program[2][2] is not None:
+          program[2][2].acquire() # pylint: disable=consider-using-with
+        self.setLight( program[2][0] ) # go
+        self.sleepEvent.wait( program[2][1] ) # go delay
+
+        self.setLight( program[3][0] ) # warning
+        if program[3][2] is not None:
+          program[3][2].release()
+        self.sleepEvent.wait(program[3][1]) # warn delay
+
+      if len( program ) <= 2:
+        self.sleepEvent.wait(program[0][1]) # stop overlap delay
+      self.setLight( program[0][0] ) # stop
+      if len( program ) > 2:
+        self.sleepEvent.wait(program[0][1]) # stop overlap delay
+      if program[0][2] is not None:
+        program[0][2].release()
+
+    print( "stopping light" )
+    for light in self.extraLights:
+      print( light )
+      # Restore addresses
+      self.strip2D.strip.artnet.addr.append(light.strip2D.strip.artnet.addr[0])
+      light.quit = True
+      light.sleepEvent.set()
+      light.thread.join()
+    self.strip2D.strip.clear()
+    self.strip2D.send()
+    time.sleep(0.001) # yield (allow sending the packet)
+
+    self.quit = False
+
+  def signal_handler(self, _signal, _frame):
+    """
+    Signal handler to kill the application
+    Usage: signal.signal(signal.SIGINT, signal_handler)
+    """
+    print('We got signal..')
+    self.quit = True
+
+    for light in self.extraLights:
+      light.quit = True
+
+
+if __name__ == "__main__":
+  e = Trafficlight(Strip2D(7, 21))
+  e.run()


### PR DESCRIPTION
This PR adds a working traffic light by dividing the sleeve in three parts and lighting a part of the strip (you might have to rotate/align the sleeve to face the "traffic".

This was an exercise to have an education/play tool for children and an education for me on working with multi threading and semaphores; it is multi sleeve compatible: only 1 sleeve will have green at a given time.

To change from Dutch type traffic light to German (red and orange for 'get ready'), set:
`traffic_prepare = [ off, yellow, red ]`
To have a delay between the light changing to red and the other light turn to green (like single lane road construction lights), look for `# intersection release time (all red)` and increase the integer.

It also has the states of a waterway bridge traffic mechanism (green in the middle); to change the program, look for:
```python
# Define the actual program here (traffic, disabled, bridge)
program = traffic
```

Please note that `strip.py` needed an extra check since threads aren't allowed to listen for `SIGINT`.
I had several stabs at this, but this was the only feasible way given the constraints of the LEDstrip control.

* multi sleeve support with Semaphores
* possible to change to UK/DE and NL/BE/FR type
* needed an extra check on SIGINT due to use of Threading
* compatible with UI app
